### PR TITLE
replaced SHOULD with MUST

### DIFF
--- a/draft-dejong-remotestorage-head.txt
+++ b/draft-dejong-remotestorage-head.txt
@@ -212,7 +212,7 @@ Internet-Draft              remoteStorage                      June 2013
 5. Response codes
 
     The following responses MUST be given in the indicated cases, in
-    order of preference, and MUST be recognized by the client:
+    order of preference, and SHOULD be recognized by the client:
 
 
 


### PR DESCRIPTION
for the following cases:
- GET requests to folders MUST be responded with a listing
- GET requests to document MUST be responded with the document content
- folders MUST be created silently
- the listed response codes MUST be given
