### PR TITLE
Rewording suggestion for OAuth wire transcript example

### DIFF
--- a/draft-dejong-remotestorage-02.txt
+++ b/draft-dejong-remotestorage-02.txt
@@ -626,7 +626,7 @@ low
     To which the server could respond with a 302 redirect, back to the
     origin of the requesting application:
 
-        HTTP/1.1 200 OK
+        HTTP/1.1 302 OK
         Location:https://drinks-unhosted.5apps.com/#access_token=j2YnGt\
 XjzzzHNjkd1CJxoQubA1o%3D&token_type=bearer&state=
 


### PR DESCRIPTION
In "12.3. OAuth dialog form submission" the spec states

> To which the server could respond with a 302 redirect, back to the
>     origin of the requesting application:

Instead of "origin", shouldn't it actually say something like "URI specified in the redirect_uri parameter"?

Also, the response example uses a 200 response code instead of 302.
