### PR TITLE
Narrow scope of 401 responses

### DIFF
--- a/source.txt
+++ b/source.txt
@@ -281,8 +281,7 @@ Table of Contents
        * 414 if the request URI is too long,
        * 416 if Range requests are supported by the server and the Range
              request can not be satisfied,
-       * 401 for all requests that don't have a bearer token with
-             sufficient permissions,
+       * 401 for all requests that do not have any bearer token,
        * 403 for all requests that either have insufficient scope, e.g. 
              accessing a <module> for which no scope was obtained, or accessing
              data outside the user's <storage_root>,


### PR DESCRIPTION
Currently 401's scope is a bit wide and overlaps with the one of 403.