### PR TITLE
client_id is already mandated by OAuth

### DIFF
--- a/source.txt
+++ b/source.txt
@@ -472,10 +472,9 @@ Table of Contents
     The server MAY expire bearer tokens, and MAY require the user to
     register applications as OAuth clients before first use; if no
     client registration is required, then the server MAY ignore the
-    value of the client_id parameter, it MUST still be sent and valid,
-    in favor of relying on the origin of the redirect_uri parameter
-    for unique client identification. See section 4 of [ORIGIN] for
-    computing the Origin.
+    value of the client_id parameter in favor of relying on the origin
+    of the redirect_uri parameter for unique client identification. See
+    section 4 of [ORIGIN] for computing the Origin.
 
 
 11. Storage-first bearer token issuance


### PR DESCRIPTION
Originally I wanted to just wrap the "it must still be sent and valid"
in parens (since the resulting sentence was extremely weird and read
like rambling).

However, client_id is already `REQUIRED` by the OAuth RFC, IMO it's not
necessary to reiterate that requirement here.