### PR TITLE
MAY ignore -> MUST ignore client_id, fix #143

### DIFF
--- a/source.txt
+++ b/source.txt
@@ -486,7 +486,7 @@ Table of Contents
 
     The server MAY expire bearer tokens, and MAY require the user to
     register applications as OAuth clients before first use; if no
-    client registration is required, then the server MAY ignore the
+    client registration is required, then the server MUST ignore the
     value of the client_id parameter in favor of relying on the origin
     of the redirect_uri parameter for unique client identification. See
     section 4 of [ORIGIN] for computing the Origin.

--- a/source.txt
+++ b/source.txt
@@ -486,10 +486,10 @@ Table of Contents
 
     The server MAY expire bearer tokens, and MAY require the user to
     register applications as OAuth clients before first use; if no
-    client registration is required, then the server MUST ignore the
-    value of the client_id parameter in favor of relying on the origin
-    of the redirect_uri parameter for unique client identification. See
-    section 4 of [ORIGIN] for computing the Origin.
+    client registration is required, the server MUST ignore the value of
+    the client_id parameter in favor of relying on the origin of the
+    redirect_uri parameter for unique client identification. See section
+    4 of [ORIGIN] for computing the origin.
 
 11. Storage-first bearer token issuance
 


### PR DESCRIPTION
With this formulation, unregistered clients can just leave out `client_id`, or set some random value which the server will ignore.

Fixes #143