### PR TITLE
Disallow quotation marks for ETags in folder descriptions

### DIFF
--- a/source.txt
+++ b/source.txt
@@ -214,6 +214,8 @@ Table of Contents
          }
        }
 
+    ETags in folder descriptions MUST omit the double quotes surrounding
+    the value in HTTP headers.
 
     GET requests to empty folders SHOULD be responded to with a folder
     description with no items (the items field set to '{}'). However, an


### PR DESCRIPTION
closes https://github.com/remotestorage/remotestorage.js/issues/1316